### PR TITLE
Need to specify db to be used for some unknown reason

### DIFF
--- a/models/address.model.js
+++ b/models/address.model.js
@@ -38,5 +38,7 @@ const userAddressSchema = new mongoose.Schema(
   { timestamps: true }
 );
 
-mongoose.model("address", addressSchema);
-module.exports = mongoose.model("userAddress", userAddressSchema);
+// Need to specify db for some unknown reason
+const myDB = mongoose.connection.useDb("milkwaledb");
+myDB.model("address", addressSchema);
+module.exports = myDB.model("userAddress", userAddressSchema);

--- a/models/admin.model.js
+++ b/models/admin.model.js
@@ -46,5 +46,7 @@ const adminSchema = new mongoose.Schema(
   { timestamps: true }
 );
 
-const adminModel = mongoose.model("adminmodel", adminSchema);
+// Need to specify db for some unknown reason
+const myDB = mongoose.connection.useDb("milkwaledb");
+const adminModel = myDB.model("adminmodel", adminSchema);
 module.exports = adminModel;

--- a/models/cart.model.js
+++ b/models/cart.model.js
@@ -28,4 +28,6 @@ const cartSchema = new mongoose.Schema(
   { timestamps: true }
 );
 
-module.exports = mongoose.model("cart", cartSchema);
+// Need to specify db for some unknown reason
+const myDB = mongoose.connection.useDb("milkwaledb");
+module.exports = myDB.model("cart", cartSchema);

--- a/models/delboy.model.js
+++ b/models/delboy.model.js
@@ -31,5 +31,7 @@ const delboySchema = new mongoose.Schema(
   { timestamps: true }
 );
 
-const delboyModel = mongoose.model("delboy", delboySchema);
+// Need to specify db for some unknown reason
+const myDB = mongoose.connection.useDb("milkwaledb");
+const delboyModel = myDB.model("delboy", delboySchema);
 module.exports = delboyModel;

--- a/models/orders.model.js
+++ b/models/orders.model.js
@@ -55,5 +55,7 @@ const orderSchema = new mongoose.Schema(
   { timestamps: true }
 );
 
-const orderModel = mongoose.model("orders", orderSchema);
+// Need to specify db for some unknown reason
+const myDB = mongoose.connection.useDb("milkwaledb");
+const orderModel = myDB.model("orders", orderSchema);
 module.exports = orderModel;

--- a/models/products.model.js
+++ b/models/products.model.js
@@ -62,5 +62,7 @@ const productSchema = new mongoose.Schema(
   { timestamps: true }
 );
 
-const productModel = mongoose.model("products", productSchema);
+// Need to specify db for some unknown reason
+const myDB = mongoose.connection.useDb("milkwaledb");
+const productModel = myDB.model("products", productSchema);
 module.exports = productModel;

--- a/models/subpack.model.js
+++ b/models/subpack.model.js
@@ -58,5 +58,7 @@ const subpackSchema = new mongoose.Schema(
   { timestamps: true }
 );
 
-const subpackModel = mongoose.model("subpacks", subpackSchema);
+// Need to specify db for some unknown reason
+const myDB = mongoose.connection.useDb("milkwaledb");
+const subpackModel = myDB.model("subpacks", subpackSchema);
 module.exports = subpackModel;

--- a/models/subscription.model.js
+++ b/models/subscription.model.js
@@ -53,5 +53,7 @@ const subscriptionSchema = new mongoose.Schema(
   { timestamps: true }
 );
 
-const subscriptionModel = mongoose.model("subscription", subscriptionSchema);
+// Need to specify db for some unknown reason
+const myDB = mongoose.connection.useDb("milkwaledb");
+const subscriptionModel = myDB.model("subscription", subscriptionSchema);
 module.exports = subscriptionModel;

--- a/models/users.model.js
+++ b/models/users.model.js
@@ -50,5 +50,7 @@ const userSchema = new mongoose.Schema(
   { timestamps: true }
 );
 
-const userModel = mongoose.model("users", userSchema);
+// Need to specify db for some unknown reason
+const myDB = mongoose.connection.useDb("milkwaledb");
+const userModel = myDB.model("users", userSchema);
 module.exports = userModel;


### PR DESCRIPTION
Might be due to some updates in the MongoDB, we have to specify the db name explicitly while referring to models